### PR TITLE
[feat] implementation of ConversationTokenBufferMemory

### DIFF
--- a/langchain/src/memory/buffer_token_memory.ts
+++ b/langchain/src/memory/buffer_token_memory.ts
@@ -35,9 +35,13 @@ export class ConversationTokenBufferMemory extends BaseChatMemory
     implements ConversationTokenBufferMemoryInput {
 
     humanPrefix = "Human";
+
     aiPrefix = "AI";
+
     memoryKey = "history";
+
     maxTokenLimit = 2000; // Default max token limit of 2000 which can be overridden
+    
     llm: BaseLanguageModel;
 
     constructor(fields: ConversationTokenBufferMemoryInput) {
@@ -90,12 +94,12 @@ export class ConversationTokenBufferMemory extends BaseChatMemory
         await super.saveContext(inputValues, outputValues);
 
         // Prune buffer if it exceeds the max token limit set for this instance.
-        let buffer = await this.chatHistory.getMessages();
+        const buffer = await this.chatHistory.getMessages();
         let currBufferLength = await this.llm.getNumTokens(
             getBufferString(buffer, this.humanPrefix, this.aiPrefix));
         
         if (currBufferLength > this.maxTokenLimit) {
-            let prunedMemory = [];
+            const prunedMemory = [];
             while (currBufferLength > this.maxTokenLimit) {
                 prunedMemory.push(buffer.shift())
                 currBufferLength = await this.llm.getNumTokens(

--- a/langchain/src/memory/buffer_token_memory.ts
+++ b/langchain/src/memory/buffer_token_memory.ts
@@ -1,0 +1,106 @@
+import { InputValues, MemoryVariables, getBufferString, OutputValues } from "./base.js";
+
+import { BaseChatMemory, BaseChatMemoryInput } from "./chat_memory.js";
+import { BaseLanguageModel } from "../base_language/index.js";
+
+
+/**
+ * Interface for the input parameters of the `BufferTokenMemory` class.
+ */
+
+export interface ConversationTokenBufferMemoryInput extends BaseChatMemoryInput {
+    /* Prefix for human messages in the buffer. */
+    humanPrefix?: string;
+
+    /* Prefix for AI messages in the buffer.*/
+    aiPrefix?: string;
+
+    /* The LLM for this instance. */
+    llm: BaseLanguageModel;
+
+    /* Memory key for buffer instance. */
+    memoryKey?: string;
+
+    /* Maximmum number of tokens allowed in the buffer. */
+    maxTokenLimit?: number;
+}
+
+/**
+ * Class that represents a conversation chat memory with a token buffer.
+ * It extends the `BaseChatMemory` class and implements the
+ * `ConversationTokenBufferMemoryInput` interface.
+ */
+
+export class ConversationTokenBufferMemory extends BaseChatMemory 
+    implements ConversationTokenBufferMemoryInput {
+
+    humanPrefix = "Human";
+    aiPrefix = "AI";
+    memoryKey = "history";
+    maxTokenLimit = 2000; // Default max token limit of 2000 which can be overridden
+    llm: BaseLanguageModel;
+
+    constructor(fields: ConversationTokenBufferMemoryInput) {
+        super({returnMessages: fields?.returnMessages ?? false,
+            chatHistory: fields?.chatHistory,
+            inputKey: fields?.inputKey,
+            outputKey: fields?.outputKey,});
+        this.llm = fields.llm;
+        this.humanPrefix = fields?.humanPrefix ?? this.humanPrefix;
+        this.aiPrefix = fields?.aiPrefix ?? this.aiPrefix;
+        this.memoryKey = fields?.memoryKey ?? this.memoryKey;
+        this.maxTokenLimit = fields?.maxTokenLimit ?? this.maxTokenLimit;
+    }
+
+    get memoryKeys() {
+        return [this.memoryKey];
+    }
+
+    /**
+    * Loads the memory variables. It takes an `InputValues` object as a
+    * parameter and returns a `Promise` that resolves with a
+    * `MemoryVariables` object.
+    * @param _values `InputValues` object.
+    * @returns A `Promise` that resolves with a `MemoryVariables` object.
+    */
+    async loadMemoryVariables(_values: InputValues): Promise<MemoryVariables> {
+        const messages = await this.chatHistory.getMessages();
+        if (this.returnMessages) {
+            const result = {
+                [this.memoryKey]: messages,
+            };
+            return result;
+        }
+        const result = {
+            [this.memoryKey]: getBufferString(
+                messages,
+                this.humanPrefix,
+                this.aiPrefix
+            ),
+        };
+        return result;
+    }
+
+    /**
+    * Saves the context from this conversation to buffer. If the amount
+    * of tokens required to save the buffer exceeds MAX_TOKEN_LIMIT,
+    * prune it. 
+    */
+    async saveContext(inputValues: InputValues, outputValues: OutputValues) {
+        await super.saveContext(inputValues, outputValues);
+
+        // Prune buffer if it exceeds the max token limit set for this instance.
+        let buffer = await this.chatHistory.getMessages();
+        let currBufferLength = await this.llm.getNumTokens(
+            getBufferString(buffer, this.humanPrefix, this.aiPrefix));
+        
+        if (currBufferLength > this.maxTokenLimit) {
+            let prunedMemory = [];
+            while (currBufferLength > this.maxTokenLimit) {
+                prunedMemory.push(buffer.shift())
+                currBufferLength = await this.llm.getNumTokens(
+                    getBufferString(buffer, this.humanPrefix, this.aiPrefix))
+            }
+        }
+    }
+}


### PR DESCRIPTION
Implementation of Conversation Token Buffer Memory, a feature already implemented in Python.

[Fixes # (issue)](https://github.com/langchain-ai/langchainjs/issues/2753)